### PR TITLE
Add support for str8/bin8/16/32 types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 MessagePack PHP functions
 =============
 
-The purpose of this project is to implement [MessagePack](http://msgpack.org/) serialization using only PHP. This might be useful for someone unable to install php-modules, or using [HipHop](https://github.com/facebook/hiphop-php) to compile PHP as C++.  
+The purpose of this project is to implement [MessagePack](http://msgpack.org/) serialization using only PHP. It aims to work even on very old versions of PHP, such as found in many long-term support server distros, while supporting the modern str8/bin8/bin16/bin32 additions to msgpack.
+
+Additions
+-----
+
+ - Supports decoding and encoding str8 and bin8/16/32 types.
+ - By analogy to the python implementation, msgpack_unpackb accepts $raw parameter determining handling of str types (default: $raw=True).
+ - By analogy to the python implementation, msgpack_packb accepts $use_bin_type parameter determining use of bin types (default: $use_bin_type=False).
+ - PHP has no concept of bytes vs unicode strings, so msgpack_packb also accepts $force_str_as_bin parameter forcing the use of bin types event for
+   strings that are valid utf-8.
 
 Caveats
 -----
 
- - Only msgpack_pack() and msgpack_unpack() are defined.
- - It's only tested on [little endian](http://en.wikipedia.org/wiki/Endianness) architecture, but should work on big endian as well, please test it if able. 
- - The uint64 and int64 types probably requires 64-bit systems to work
+ - Only msgpack_packb() and msgpack_unpackb() are defined.
+ - It's only tested on [little endian](http://en.wikipedia.org/wiki/Endianness) architecture, but should work on big endian as well. 
  - It uses is_x() to select the type, do your casts before using the functions
- - Unlike the official lib you can't pack objects. If you know how to do this please fork.
+ - Unlike the official lib you can't pack objects. Feel free to submit a pull request to add this functionality.
  - It will always pack integers into the least amount of bits possible, and will prefer unsigned.
- 
+ - It does not support ext/fixext types.
  
 Benchmark
 -----

--- a/msgpack.php
+++ b/msgpack.php
@@ -1,14 +1,78 @@
 <?php
 
 /**
+ * Determine if string is valid UTF-8 encoding. This does not mean
+ * that it is necessarily a UTF-8 string, but is used to decide on the
+ * default type if not explicitly set otherwise. It is not
+ * constant time.
+ *
+ * A string is valid UTF-8 if all of the following are true:
+ * 1. Single byte characters are 0xxxxxxx (00-7F)
+ * 2. Two byte characters are 110xxxxx 10xxxxxx ((C,D)X (8,9,A,B)Y)
+ * 3. Three byte characters are 1110xxxx 10xxxxxx 10xxxxxx (EX (8,9,A,B)Y (8,9,A,B)Z)
+ * 4. Four byte characters are 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx (FX (8,9,A,B)Y (8,9,A,B)Z (8,9,A,B)W)
+ * 5. Does not contain disallowed bytes (hex):
+ *    C0, C1, F5, F6, F7, F8, F9, FA, FB, FC, FD, FE, FF
+ * 6. If first byte is E0 or F0, second byte must be >=A0
+ * 7. If first byte is F4, second byte must be <84
+ * 8. If first byte is ED, second byte must be <A0
+ *
+ * @param string $input
+ * @return boolean
+ */
+function is_disallowed_utf8($inp) 
+{
+    if ($inp == 0xC0 || $inp == 0xC1 || $inp >= 0xF5) return true;
+    return false;
+}
+function is_utf8($input)
+{
+    $pos = 0;
+    while ($pos < strlen($input)) {
+      $byte = ord(substr($input,$pos++,1));
+      if (is_disallowed_utf8($byte)) return false; // not allowed character
+      if ($byte >= 0xC0 && $byte <= 0xDF) {
+        // two-byte sequence
+        if ($pos+1 > strlen($input)) return false; // too short
+        $byte2 = ord(substr($input,$pos++,1));
+        if ($byte2 < 0x80 || $byte2 > 0xBF || is_disallowed_utf8($byte2)) return false; // not continuation byte
+      } else if ($byte >= 0xE0 && $byte <= 0xEF) {
+        // three-byte sequence
+        if ($pos+2 > strlen($input)) return false; // too short
+        $byte2 = ord(substr($input,$pos++,1));
+        $byte3 = ord(substr($input,$pos++,1));
+        if ($byte == 0xE0 && $byte2 < 0xA0) return false; // overlong (should be only two bytes)
+        if ($byte == 0xED && $byte2 >= 0xA0) return false; // surrogate halves reserved for UTF-16
+        if ($byte2 < 0x80 || $byte2 > 0xBF || is_disallowed_utf8($byte2)) return false; // not continuation byte
+        if ($byte3 < 0x80 || $byte3 > 0xBF || is_disallowed_utf8($byte3)) return false; // not continuation byte
+      } else if ($byte >= 0xF0 && $byte <0xFF) {
+        // four-byte sequence
+        if ($pos+3 > strlen($input)) return false; // too short
+        $byte2 = ord(substr($input,$pos++,1));
+        $byte3 = ord(substr($input,$pos++,1));
+        $byte4 = ord(substr($input,$pos++,1));
+        if ($byte == 0xF0 && $byte2 < 0xA0) return false; // overlong (should be only three bytes)
+        if ($byte2 < 0x80 || $byte2 > 0xBF || is_disallowed_utf8($byte2)) return false; // not continuation byte
+        if ($byte3 < 0x80 || $byte3 > 0xBF || is_disallowed_utf8($byte3)) return false; // not continuation byte
+        if ($byte4 < 0x80 || $byte4 > 0xBF || is_disallowed_utf8($byte4)) return false; // not continuation byte
+      }
+      // otherwise, 0x00-0x7F, valid UTF-8 bytes 
+    }
+    return true;
+}
+
+
+/**
  * Pack some input into msgpack format.
  * Format specs: https://github.com/msgpack/msgpack/blob/master/spec.md
  *
  * @param mixed $input
+ * @param boolean $use_bin_type=False
+ * @param boolean $force_str_as_bin=False
  * @return string
  * @throws \InvalidArgumentException
  */
-function msgpack_pack($input)
+function msgpack_packb($input, $use_bin_type=False, $force_str_as_bin=False)
 {
     static $bigendian;
     if (!isset($bigendian)) $bigendian = (pack('S',1)==pack('n',1));
@@ -70,19 +134,34 @@ function msgpack_pack($input)
         return pack('C',0xCB).($bigendian ? pack('d',$input) : strrev(pack('d',$input)));
     }
 
-    // Strings/Raw
-    if (is_string($input)) {
+    // Strings / Binary
+    if (is_string($input) && (!$use_bin_type || (!$force_str_as_bin && is_utf8($input)))) {
         $len = strlen($input);
-        if ($len<32) {
+        if ($len<32) { //fixstr
             return pack('Ca*',0xA0|$len,$input);
-        } else if ($len<=0xFFFF) {
+        } else if ($len<=0xFF && $use_bin_type) { //str8 only if bin types are available
+            return pack('CCa*',0xD9,$len,$input);
+        } else if ($len<=0xFFFF) { //str16
             return pack('Cna*',0xDA,$len,$input);
-        } else if ($len<=0xFFFFFFFF) {
+        } else if ($len<=0xFFFFFFFF) { //str32
             return pack('CNa*',0xDB,$len,$input);
         } else {
             throw new \InvalidArgumentException('Input overflows (2^32)-1 byte max');
         }
     }
+    if (is_string($input) && ($use_bin_type && ($force_str_as_bin || !is_utf8($input)))) {
+        $len = strlen($input);
+        if ($len<=0xFF) { //bin8
+            return pack('CCa*',0xC4,$len,$input);
+        } else if ($len<=0xFFFF) { //bin16
+            return pack('Cna*',0xC5,$len,$input);
+        } else if ($len<=0xFFFFFFFF) { //bin32
+            return pack('CNa*',0xC6,$len,$input);
+        } else {
+            throw new \InvalidArgumentException('Input overflows (2^32)-1 byte max');
+        }
+    }
+
 
     // Arrays & Maps
     if (is_array($input)) {
@@ -110,8 +189,8 @@ function msgpack_pack($input)
         }
 
         foreach ($input as $key => $elm) {
-            if ($isMap) $buf .= msgpack_pack($key);
-            $buf .= msgpack_pack($elm);
+            if ($isMap) $buf .= msgpack_packb($key, $use_bin_type, $force_str_as_bin);
+            $buf .= msgpack_packb($elm, $use_bin_type, $force_str_as_bin);
         }
         return $buf;
 
@@ -124,22 +203,18 @@ function msgpack_pack($input)
  * Unpack data from a msgpack'ed string
  *
  * @param string $input
+ * @param boolean $raw=True
  * @return mixed
  */
-function msgpack_unpack($input)
+function msgpack_unpackb($input, $raw=True)
 {
     static $bigendian;
     if (!isset($bigendian)) $bigendian = (pack('S',1)==pack('n',1));
 
-    // Store input into a memory buffer so we can operate on it with filepointers
+    // Use static variables so we can more easily handle recursive decoding
     static $buffer;
     static $pos;
-    if (!isset($buffer)) {
-        $buffer = $input;
-        $pos = 0;
-    }
-
-    if ($pos==strlen($buffer)) {
+    if (!isset($buffer) || ($buffer!=$input) || $pos==strlen($buffer)) {
         $buffer = $input;
         $pos = 0;
     }
@@ -165,22 +240,24 @@ function msgpack_unpack($input)
         return current(unpack('c',$byte&"\xFF"));
     }
 
-    // fixed raw
+    // fixstr
     if ((($byte ^ "\xA0") & "\xE0") == "\x00") {
         $len = current(unpack('c',($byte ^ "\xA0")));
         if ($len == 0) return "";
         $d = substr($buffer,$pos,$len);
         $pos+=$len;
-        return current(unpack('a'.$len,$d));
+        $toret = current(unpack('a'.$len,$d));
+        if ($raw || is_utf8($toret)) return $toret;
+        throw new \InvalidArgumentException('Can\'t unpack fixstr data that is not valid utf8: '.$toret);
     }
 
-    // Arrays
+    // fixarray, array16/32
     if ((($byte ^ "\x90") & "\xF0") == "\x00") {
         // fixed array
         $len = current(unpack('c',($byte ^ "\x90")));
         $data = array();
         for($i=0;$i<$len;$i++) {
-            $data[] = msgpack_unpack($input);
+            $data[] = msgpack_unpackb($input, $raw);
         }
         return $data;
     } else if ($byte == "\xDC" || $byte == "\xDD") {
@@ -196,19 +273,19 @@ function msgpack_unpack($input)
         }
         $data = array();
         for($i=0;$i<$len;$i++) {
-            $data[] = msgpack_unpack($input);
+            $data[] = msgpack_unpackb($input, $raw);
         }
         return $data;
     }
 
-    // Maps
+    // fixmap, map16/32
     if ((($byte ^ "\x80") & "\xF0") == "\x00") {
         // fixed map
         $len = current(unpack('c',($byte ^ "\x80")));
         $data = array();
         for($i=0;$i<$len;$i++) {
-            $key = msgpack_unpack($input);
-            $value = msgpack_unpack($input);
+            $key = msgpack_unpackb($input, $raw);
+            $value = msgpack_unpackb($input, $raw);
             $data[$key] = $value;
         }
         return $data;
@@ -225,8 +302,8 @@ function msgpack_unpack($input)
         }
         $data = array();
         for($i=0;$i<$len;$i++) {
-            $key = msgpack_unpack($input);
-            $value = msgpack_unpack($input);
+            $key = msgpack_unpackb($input, $raw);
+            $value = msgpack_unpackb($input, $raw);
             $data[$key] = $value;
         }
         return $data;
@@ -278,15 +355,52 @@ function msgpack_unpack($input)
         //   high bit is set, on 64-bit machines
         $dat['p1'] = $dat['p1'] << 32;
         return (($dat['p1']|$dat['p2'])+1)*-1;
-        // String / Raw
-    case "\xDA": // raw 16
+
+        // str8/16/32
+    case "\xD9": // str8
+        $d = substr($buffer,$pos,1);
+        $pos+=1;
+        $len = current(unpack('C',$d));
+        $d = substr($buffer,$pos,$len);
+        $pos+=$len;
+        $toret = current(unpack('a'.$len,$d));
+        if ($raw || is_utf8($toret)) return $toret;
+        throw new \InvalidArgumentException('Can\'t unpack str8 data that is not valid utf8: '.$toret);
+    case "\xDA": // str16
+        $d = substr($buffer,$pos,2);
+        $pos+=2;
+        $len = current(unpack('n',$d));
+        $d = substr($buffer,$pos,$len);
+        $pos+=$len;
+        $toret = current(unpack('a'.$len,$d));
+        if ($raw || is_utf8($toret)) return $toret;
+        throw new \InvalidArgumentException('Can\'t unpack str16 data that is not valid utf8: '.$toret);
+    case "\xDB": // str32
+        $d = substr($buffer,$pos,4);
+        $pos+=4;
+        $len = current(unpack('N',$d));
+        $d = substr($buffer,$pos,$len);
+        $pos+=$len;
+        $toret = current(unpack('a'.$len,$d));
+        if ($raw || is_utf8($toret)) return $toret;
+        throw new \InvalidArgumentException('Can\'t unpack str32 data that is not valid utf8: '.$toret);
+
+        // bin8/16/32
+    case "\xC4": // bin8
+        $d = substr($buffer,$pos,1);
+        $pos+=1;
+        $len = current(unpack('C',$d));
+        $d = substr($buffer,$pos,$len);
+        $pos+=$len;
+        return current(unpack('a'.$len,$d));
+    case "\xC5": // bin16
         $d = substr($buffer,$pos,2);
         $pos+=2;
         $len = current(unpack('n',$d));
         $d = substr($buffer,$pos,$len);
         $pos+=$len;
         return current(unpack('a'.$len,$d));
-    case "\xDB": // raw 32
+    case "\xC6": // bin32
         $d = substr($buffer,$pos,4);
         $pos+=4;
         $len = current(unpack('N',$d));
@@ -306,5 +420,6 @@ function msgpack_unpack($input)
 
     }
 
+    // Not handled: ext8/16/32, fixext1/2/4/8/16, (never used byte)
     throw new \InvalidArgumentException('Can\'t unpack data with byte-header: '.$byte);
 }

--- a/msgpackTest.php
+++ b/msgpackTest.php
@@ -13,7 +13,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testRoundTrip($val)
     {
-        $this->assertEquals($val, msgpack_unpack(msgpack_pack($val)));
+        $this->assertEquals($val, msgpack_unpackb(msgpack_packb($val)));
     }
 
     public function roundTripProvider()
@@ -77,7 +77,7 @@ class DataTest extends PHPUnit_Framework_TestCase
     public function testShortIntTrip()
     {
         for ($i = -0x10000; $i <= 0x10000; $i += 29) {
-            $this->assertEquals($i, msgpack_unpack(msgpack_pack($i)));
+            $this->assertEquals($i, msgpack_unpackb(msgpack_packb($i)));
         }
     }
 
@@ -88,7 +88,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testNegatives($hex, $val)
     {
-        $this->assertEquals($val, msgpack_unpack(hex2bin($hex)));
+        $this->assertEquals($val, msgpack_unpackb(hex2bin($hex)));
     }
 
     public function negativesProvider()

--- a/test.php
+++ b/test.php
@@ -9,8 +9,8 @@ require_once 'msgpack.php';
 function test($type, $var)
 {
 	echo "================\n".$type."\n";
-	$e = msgpack_pack($var);
-	$d = msgpack_unpack($e);
+	$e = msgpack_packb($var);
+	$d = msgpack_unpackb($e);
 
 	echo "\t".bin2hex($e)."\t".$e."\n\t";
 	echo str_replace("\n","\n\t",var_export($d,true))."\n";


### PR DESCRIPTION
This pull request implements the necessary logic to enable msgpack-php to support the distinction between strings and binary bytes as supported by more recent versions of msgpack. 

Additions
-----

 - Supports decoding and encoding str8 and bin8/16/32 types.
 - By analogy to the python implementation, msgpack_unpackb accepts $raw parameter determining handling of str types (default: $raw=True).
 - By analogy to the python implementation, msgpack_packb accepts $use_bin_type parameter determining use of bin types (default: $use_bin_type=False).
 - PHP has no concept of bytes vs unicode strings, so msgpack_packb also accepts $force_str_as_bin parameter forcing the use of bin types event for strings that are valid utf-8.

The minimum and maximum suitable PHP versions are unchanged.

Testing: Each newly added type was tested for compatibility with the python msgpack implementation, in both encoding and decoding directions. It has been in production for about a year with no more known bugs.